### PR TITLE
[feature] Automatic cache flushing

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,24 +135,9 @@ class Kid extends Model
 Kid::flushQueryCache();
 ```
 
-## Relationship Caching
-
-Relationships are just another queries. They can be intercepted and modified before the database is hit with the query. The following example needs the `Order` model (or the model associated with the `orders` relationship) to include the `QueryCacheable` trait.
-
-```php
-$user = User::with(['orders' => function ($query) {
-    return $query
-        ->cacheFor(60 * 60)
-        ->cacheTags(['my:orders']);
-}])->get();
-
-// This comes from the cache if existed.
-$orders = $user->orders;
-```
-
 ## Full Automatic Invalidation
 
-To speed up the scaffolding of invalidation within your app, you can specify the model to auto-flush the cache upon any model gets created, updated or deleted.
+To speed up the scaffolding of invalidation within your app, you can specify the model to auto-flush the cache upon any time records gets created, updated or deleted.
 
 ```php
 class Page extends Model
@@ -223,6 +208,21 @@ $page->update([
 **Please keep in mind: Setting `$flushCacheOnUpdate` to `true` and not specifying individual tags to invalidate will lead to [Full Automatic Invalidation](#full-automatic-invalidation) since the default tags to invalidate are the base tags and you need at least one tag to invalidate.**
 
 **Not specifying a tag to invalidate fallbacks to the set of base tags, thus leading to Full Automatic Invalidation.**
+
+## Relationship Caching
+
+Relationships are just another queries. They can be intercepted and modified before the database is hit with the query. The following example needs the `Order` model (or the model associated with the `orders` relationship) to include the `QueryCacheable` trait.
+
+```php
+$user = User::with(['orders' => function ($query) {
+    return $query
+        ->cacheFor(60 * 60)
+        ->cacheTags(['my:orders']);
+}])->get();
+
+// This comes from the cache if existed.
+$orders = $user->orders;
+```
 
 ## Cache Keys
 

--- a/database/factories/PageFactory.php
+++ b/database/factories/PageFactory.php
@@ -1,0 +1,19 @@
+<?php
+/*
+|--------------------------------------------------------------------------
+| Model Factories
+|--------------------------------------------------------------------------
+|
+| This directory should contain each of the model factory definitions for
+| your application. Factories provide a convenient way to generate new
+| model instances for testing / seeding your application's database.
+|
+*/
+
+use Illuminate\Support\Str;
+
+$factory->define(\Rennokki\QueryCache\Test\Models\Page::class, function () {
+    return [
+        'name' => 'Page'.Str::random(5),
+    ];
+});

--- a/src/FlushQueryCacheObserver.php
+++ b/src/FlushQueryCacheObserver.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Rennokki\QueryCache;
+
+use Illuminate\Database\Eloquent\Model;
+
+class FlushQueryCacheObserver
+{
+    /**
+     * Handle the Model "created" event.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return void
+     */
+    public function created(Model $model)
+    {
+        $this->invalidateCache($model);
+    }
+
+    /**
+     * Handle the Model "updated" event.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return void
+     */
+    public function updated(Model $model)
+    {
+        $this->invalidateCache($model);
+    }
+
+    /**
+     * Handle the Model "deleted" event.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return void
+     */
+    public function deleted(Model $model)
+    {
+        $this->invalidateCache($model);
+    }
+
+    /**
+     * Handle the Model "forceDeleted" event.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return void
+     */
+    public function forceDeleted(Model $model)
+    {
+        $this->invalidateCache($model);
+    }
+
+    /**
+     * Handle the Model "restored" event.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return void
+     */
+    public function restored(Model $model)
+    {
+        $this->invalidateCache($model);
+    }
+
+    /**
+     * Invalidate the cache for a model.
+     *
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return void
+     * @throws Exception
+     */
+    protected function invalidateCache(Model $model): void
+    {
+        if (! $model->getCacheTagsToInvalidateOnUpdate()) {
+            throw new Exception('Automatic invalidation for '.$class.' works only if at least one tag to be invalidated is specified.');
+        }
+
+        $class = get_class($model);
+
+        $class::flushQueryCache(
+            $model->getCacheTagsToInvalidateOnUpdate()
+        );
+    }
+}

--- a/src/Traits/QueryCacheable.php
+++ b/src/Traits/QueryCacheable.php
@@ -2,10 +2,50 @@
 
 namespace Rennokki\QueryCache\Traits;
 
+use Illuminate\Database\Eloquent\Model;
+use Rennokki\QueryCache\FlushQueryCacheObserver;
 use Rennokki\QueryCache\Query\Builder;
 
 trait QueryCacheable
 {
+    /**
+     * Get the observer class name that will
+     * observe the changes and will invalidate the cache
+     * upon database change.
+     *
+     * @return string
+     */
+    protected static function getFlushQueryCacheObserver()
+    {
+        return FlushQueryCacheObserver::class;
+    }
+
+    /**
+     * When invalidating automatically on update, you can specify
+     * which tags to invalidate.
+     *
+     * @return array
+     */
+    public function getCacheTagsToInvalidateOnUpdate(): array
+    {
+        return $this->getCacheBaseTags();
+    }
+
+    /**
+     * {@inheritdoc}
+     *
+     */
+    public static function boot()
+    {
+        parent::boot();
+
+        if (isset(static::$flushCacheOnUpdate) && static::$flushCacheOnUpdate) {
+            static::observe(
+                static::getFlushQueryCacheObserver()
+            );
+        }
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/tests/FlushCacheOnUpdateTest.php
+++ b/tests/FlushCacheOnUpdateTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Rennokki\QueryCache\Test;
+
+use Cache;
+use Rennokki\QueryCache\Test\Models\Page;
+use Rennokki\QueryCache\Test\Models\Post;
+
+class FlushCacheOnUpdateTest extends TestCase
+{
+    public function test_flush_cache_on_create()
+    {
+        $page = factory(Page::class)->create();
+        $storedPage = Page::cacheFor(now()->addHours(1))->first();
+        $cache = Cache::tags(['test'])->get('leqc:sqlitegetselect * from "pages" limit 1a:0:{}');
+
+        $this->assertNotNull($cache);
+
+        $this->assertEquals(
+            $cache->first()->id,
+            $storedPage->id
+        );
+
+        Page::create([
+            'name' => '9GAG',
+        ]);
+
+        $cache = Cache::tags(['test'])->get('leqc:sqlitegetselect * from "pages" limit 1a:0:{}');
+
+        $this->assertNull($cache);
+    }
+
+    public function test_flush_cache_on_update()
+    {
+        $page = factory(Page::class)->create();
+        $storedPage = Page::cacheFor(now()->addHours(1))->first();
+        $cache = Cache::tags(['test'])->get('leqc:sqlitegetselect * from "pages" limit 1a:0:{}');
+
+        $this->assertNotNull($cache);
+
+        $this->assertEquals(
+            $cache->first()->id,
+            $storedPage->id
+        );
+
+        $page->update([
+            'name' => '9GAG',
+        ]);
+
+        $cache = Cache::tags(['test'])->get('leqc:sqlitegetselect * from "pages" limit 1a:0:{}');
+
+        $this->assertNull($cache);
+    }
+
+    public function test_flush_cache_on_delete()
+    {
+        $page = factory(Page::class)->create();
+        $storedPage = Page::cacheFor(now()->addHours(1))->first();
+        $cache = Cache::tags(['test'])->get('leqc:sqlitegetselect * from "pages" limit 1a:0:{}');
+
+        $this->assertNotNull($cache);
+
+        $this->assertEquals(
+            $cache->first()->id,
+            $storedPage->id
+        );
+
+        $page->delete();
+
+        $cache = Cache::tags(['test'])->get('leqc:sqlitegetselect * from "pages" limit 1a:0:{}');
+
+        $this->assertNull($cache);
+    }
+
+    public function test_flush_cache_on_force_deletion()
+    {
+        $page = factory(Page::class)->create();
+        $storedPage = Page::cacheFor(now()->addHours(1))->first();
+        $cache = Cache::tags(['test'])->get('leqc:sqlitegetselect * from "pages" limit 1a:0:{}');
+
+        $this->assertNotNull($cache);
+
+        $this->assertEquals(
+            $cache->first()->id,
+            $storedPage->id
+        );
+
+        $page->forceDelete();
+
+        $cache = Cache::tags(['test'])->get('leqc:sqlitegetselect * from "pages" limit 1a:0:{}');
+
+        $this->assertNull($cache);
+    }
+}

--- a/tests/Models/Page.php
+++ b/tests/Models/Page.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Rennokki\QueryCache\Test\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Rennokki\QueryCache\Traits\QueryCacheable;
+
+class Page extends Model
+{
+    use QueryCacheable;
+
+    protected static $flushCacheOnUpdate = true;
+
+    protected $cacheUsePlainKey = true;
+
+    protected $fillable = [
+        'name',
+    ];
+
+    protected function getCacheBaseTags(): array
+    {
+        return [
+            'test',
+        ];
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -57,6 +57,7 @@ abstract class TestCase extends Orchestra
         $app['config']->set('auth.providers.posts.model', Post::class);
         $app['config']->set('auth.providers.kids.model', Kid::class);
         $app['config']->set('auth.providers.books.model', Book::class);
+        $app['config']->set('auth.providers.pages.model', Page::class);
         $app['config']->set('app.key', 'wslxrEFGWY6GfGhvN9L3wH3KSRJQQpBD');
     }
 

--- a/tests/database/migrations/2018_07_14_183253_pages.php
+++ b/tests/database/migrations/2018_07_14_183253_pages.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class Pages extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('pages', function (Blueprint $table) {
+            $table->increments('id');
+            $table->string('name');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('pages');
+    }
+}


### PR DESCRIPTION
This idea comes from a suggestion that was sent to me via mail.

Basically, it adds an integrated scaffolding to invalidate the cache anytime a record gets created, updated or deleted.