### PR TITLE
[Fix] Fixed booting method

### DIFF
--- a/src/Traits/QueryCacheable.php
+++ b/src/Traits/QueryCacheable.php
@@ -31,12 +31,12 @@ trait QueryCacheable
     }
 
     /**
-     * {@inheritdoc}
+     * Boot the trait.
+     *
+     * @return void
      */
-    public static function boot()
+    public static function bootQueryCacheable()
     {
-        parent::boot();
-
         if (isset(static::$flushCacheOnUpdate) && static::$flushCacheOnUpdate) {
             static::observe(
                 static::getFlushQueryCacheObserver()


### PR DESCRIPTION
In #32, it is told that the boot() should not be replaced at the trait level and explained how.

Read more about booting the eloquent model traits: https://www.archybold.com/blog/post/booting-eloquent-model-traits