### PR TITLE
[fix] Non-taggable drivers support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,9 @@ jobs:
         composer update --no-interaction --prefer-stable
     - name: Run tests
       run: |
-        phpunit --coverage-text --coverage-clover=coverage.xml
+        CACHE_DRIVER=array phpunit --coverage-text --coverage-clover=coverage_array.xml
+        CACHE_DRIVER=file phpunit --coverage-text --coverage-clover=coverage_file.xml
     - uses: codecov/codecov-action@v1
       with:
         fail_ci_if_error: false
+        file: '*.xml'

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.phar
 composer.lock
 .DS_Store
+database.sqlite

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,4 +19,7 @@
             <directory suffix=".php">src/</directory>
         </whitelist>
     </filter>
+    <php>
+        <server name="APP_ENV" value="testing" />
+    </php>
 </phpunit>

--- a/src/Traits/QueryCacheModule.php
+++ b/src/Traits/QueryCacheModule.php
@@ -2,6 +2,7 @@
 
 namespace Rennokki\QueryCache\Traits;
 
+use BadMethodCallException;
 use DateTime;
 
 trait QueryCacheModule
@@ -192,11 +193,11 @@ trait QueryCacheModule
     {
         $cache = $this->getCacheDriver();
 
-        if (! method_exists($cache, 'tags')) {
-            return false;
+        try {
+            return $cache->tags($tag)->flush();
+        } catch (BadMethodCallException $e) {
+            return $cache->flush();
         }
-
-        return $cache->tags($tag)->flush();
     }
 
     /**
@@ -334,7 +335,11 @@ trait QueryCacheModule
             $this->getCacheBaseTags() ?: []
         );
 
-        return $tags ? $cache->tags($tags) : $cache;
+        try {
+            return $tags ? $cache->tags($tags) : $cache;
+        } catch (BadMethodCallException $e) {
+            return $cache;
+        }
     }
 
     /**

--- a/tests/FlushCacheOnUpdateTest.php
+++ b/tests/FlushCacheOnUpdateTest.php
@@ -11,7 +11,7 @@ class FlushCacheOnUpdateTest extends TestCase
     {
         $page = factory(Page::class)->create();
         $storedPage = Page::cacheFor(now()->addHours(1))->first();
-        $cache = Cache::tags(['test'])->get('leqc:sqlitegetselect * from "pages" limit 1a:0:{}');
+        $cache = $this->getCacheWithTags('leqc:sqlitegetselect * from "pages" limit 1a:0:{}', ['test']);
 
         $this->assertNotNull($cache);
 
@@ -24,7 +24,7 @@ class FlushCacheOnUpdateTest extends TestCase
             'name' => '9GAG',
         ]);
 
-        $cache = Cache::tags(['test'])->get('leqc:sqlitegetselect * from "pages" limit 1a:0:{}');
+        $cache = $this->getCacheWithTags('leqc:sqlitegetselect * from "pages" limit 1a:0:{}', ['test']);
 
         $this->assertNull($cache);
     }
@@ -33,7 +33,7 @@ class FlushCacheOnUpdateTest extends TestCase
     {
         $page = factory(Page::class)->create();
         $storedPage = Page::cacheFor(now()->addHours(1))->first();
-        $cache = Cache::tags(['test'])->get('leqc:sqlitegetselect * from "pages" limit 1a:0:{}');
+        $cache = $this->getCacheWithTags('leqc:sqlitegetselect * from "pages" limit 1a:0:{}', ['test']);
 
         $this->assertNotNull($cache);
 
@@ -46,7 +46,7 @@ class FlushCacheOnUpdateTest extends TestCase
             'name' => '9GAG',
         ]);
 
-        $cache = Cache::tags(['test'])->get('leqc:sqlitegetselect * from "pages" limit 1a:0:{}');
+        $cache = $this->getCacheWithTags('leqc:sqlitegetselect * from "pages" limit 1a:0:{}', ['test']);
 
         $this->assertNull($cache);
     }
@@ -55,7 +55,7 @@ class FlushCacheOnUpdateTest extends TestCase
     {
         $page = factory(Page::class)->create();
         $storedPage = Page::cacheFor(now()->addHours(1))->first();
-        $cache = Cache::tags(['test'])->get('leqc:sqlitegetselect * from "pages" limit 1a:0:{}');
+        $cache = $this->getCacheWithTags('leqc:sqlitegetselect * from "pages" limit 1a:0:{}', ['test']);
 
         $this->assertNotNull($cache);
 
@@ -66,7 +66,7 @@ class FlushCacheOnUpdateTest extends TestCase
 
         $page->delete();
 
-        $cache = Cache::tags(['test'])->get('leqc:sqlitegetselect * from "pages" limit 1a:0:{}');
+        $cache = $this->getCacheWithTags('leqc:sqlitegetselect * from "pages" limit 1a:0:{}', ['test']);
 
         $this->assertNull($cache);
     }
@@ -75,7 +75,7 @@ class FlushCacheOnUpdateTest extends TestCase
     {
         $page = factory(Page::class)->create();
         $storedPage = Page::cacheFor(now()->addHours(1))->first();
-        $cache = Cache::tags(['test'])->get('leqc:sqlitegetselect * from "pages" limit 1a:0:{}');
+        $cache = $this->getCacheWithTags('leqc:sqlitegetselect * from "pages" limit 1a:0:{}', ['test']);
 
         $this->assertNotNull($cache);
 
@@ -86,7 +86,7 @@ class FlushCacheOnUpdateTest extends TestCase
 
         $page->forceDelete();
 
-        $cache = Cache::tags(['test'])->get('leqc:sqlitegetselect * from "pages" limit 1a:0:{}');
+        $cache = $this->getCacheWithTags('leqc:sqlitegetselect * from "pages" limit 1a:0:{}', ['test']);
 
         $this->assertNull($cache);
     }

--- a/tests/FlushCacheOnUpdateTest.php
+++ b/tests/FlushCacheOnUpdateTest.php
@@ -2,7 +2,6 @@
 
 namespace Rennokki\QueryCache\Test;
 
-use Cache;
 use Rennokki\QueryCache\Test\Models\Page;
 
 class FlushCacheOnUpdateTest extends TestCase

--- a/tests/MethodsTest.php
+++ b/tests/MethodsTest.php
@@ -36,10 +36,15 @@ class MethodsTest extends TestCase
         $post = factory(Post::class)->create();
         $storedPost = Post::cacheFor(now()->addHours(1))->cacheTags(['test'])->first();
 
-        $cache = Cache::get('leqc:sqlitegetselect * from "posts" limit 1a:0:{}');
-        $this->assertNull($cache);
+        $cache = $this->getCacheWithTags('leqc:sqlitegetselect * from "posts" limit 1a:0:{}');
 
-        $cache = Cache::tags(['test'])->get('leqc:sqlitegetselect * from "posts" limit 1a:0:{}');
+        // The caches that do not support tagging should
+        // cache the query either way.
+        $this->driverSupportsTags()
+            ? $this->assertNull($cache)
+            : $this->assertNotNull($cache);
+
+        $cache = $this->getCacheWithTags('leqc:sqlitegetselect * from "posts" limit 1a:0:{}', ['test']);
         $this->assertNotNull($cache);
     }
 
@@ -48,12 +53,12 @@ class MethodsTest extends TestCase
         $post = factory(Post::class)->create();
         $storedPost = Post::cacheFor(now()->addHours(1))->cacheTags(['test'])->first();
 
-        $cache = Cache::tags(['test'])->get('leqc:sqlitegetselect * from "posts" limit 1a:0:{}');
+        $cache = $this->getCacheWithTags('leqc:sqlitegetselect * from "posts" limit 1a:0:{}', ['test']);
         $this->assertNotNull($cache);
 
         Post::flushQueryCache(['test']);
 
-        $cache = Cache::tags(['test'])->get('leqc:sqlitegetselect * from "posts" limit 1a:0:{}');
+        $cache = $this->getCacheWithTags('leqc:sqlitegetselect * from "posts" limit 1a:0:{}', ['test']);
         $this->assertNull($cache);
     }
 
@@ -62,14 +67,19 @@ class MethodsTest extends TestCase
         $post = factory(Post::class)->create();
         $storedPost = Post::cacheFor(now()->addHours(1))->cacheTags(['test'])->first();
 
-        $cache = Cache::tags(['test'])->get('leqc:sqlitegetselect * from "posts" limit 1a:0:{}');
+        $cache = $this->getCacheWithTags('leqc:sqlitegetselect * from "posts" limit 1a:0:{}', ['test']);
         $this->assertNotNull($cache);
 
         Post::flushQueryCache(['test2']);
         Post::flushQueryCacheWithTag('test2');
 
-        $cache = Cache::tags(['test'])->get('leqc:sqlitegetselect * from "posts" limit 1a:0:{}');
-        $this->assertNotNull($cache);
+        $cache = $this->getCacheWithTags('leqc:sqlitegetselect * from "posts" limit 1a:0:{}', ['test']);
+
+        // The caches that do not support tagging should
+        // flush the cache either way since tags are not supported.
+        $this->driverSupportsTags()
+            ? $this->assertNotNull($cache)
+            : $this->assertNull($cache);
     }
 
     public function test_cache_flush_with_more_tags()
@@ -77,7 +87,7 @@ class MethodsTest extends TestCase
         $post = factory(Post::class)->create();
         $storedPost = Post::cacheFor(now()->addHours(1))->cacheTags(['test'])->first();
 
-        $cache = Cache::tags(['test'])->get('leqc:sqlitegetselect * from "posts" limit 1a:0:{}');
+        $cache = $this->getCacheWithTags('leqc:sqlitegetselect * from "posts" limit 1a:0:{}', ['test']);
         $this->assertNotNull($cache);
 
         Post::flushQueryCache([
@@ -86,7 +96,7 @@ class MethodsTest extends TestCase
             'test3',
         ]);
 
-        $cache = Cache::tags(['test'])->get('leqc:sqlitegetselect * from "posts" limit 1a:0:{}');
+        $cache = $this->getCacheWithTags('leqc:sqlitegetselect * from "posts" limit 1a:0:{}', ['test']);
         $this->assertNull($cache);
     }
 
@@ -95,12 +105,12 @@ class MethodsTest extends TestCase
         $book = factory(Book::class)->create();
         $storedBook = Book::cacheFor(now()->addHours(1))->cacheTags(['test'])->first();
 
-        $cache = Cache::tags(['test', Book::getCacheBaseTags()[0]])->get('leqc:sqlitegetselect * from "books" limit 1a:0:{}');
+        $cache = $this->getCacheWithTags('leqc:sqlitegetselect * from "books" limit 1a:0:{}', ['test', Book::getCacheBaseTags()[0]]);
         $this->assertNotNull($cache);
 
         Book::flushQueryCache();
 
-        $cache = Cache::tags(['test', Book::getCacheBaseTags()[0]])->get('leqc:sqlitegetselect * from "books" limit 1a:0:{}');
+        $cache = $this->getCacheWithTags('leqc:sqlitegetselect * from "books" limit 1a:0:{}', ['test', Book::getCacheBaseTags()[0]]);
 
         $this->assertNull($cache);
     }


### PR DESCRIPTION
This PR addresses a fix to the issue like https://github.com/renoki-co/laravel-eloquent-query-cache/issues/29, where the package cannot be used for non-taggable drivers, like `database` or `file`, without having to face an exception.

Thus said, non-taggable drivers are supported starting with this PR. 🎉 