### PR TITLE
Append cache tags

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -45,7 +45,7 @@ class Builder extends BaseBuilder implements QueryCacheModuleInterface
      */
     public function selectSub($query, $as)
     {
-        if(get_class($query) == self::class) {
+        if (get_class($query) == self::class) {
             $this->appendCacheTags($query->getCacheTags() ?? []);
         }
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -33,4 +33,22 @@ class Builder extends BaseBuilder implements QueryCacheModuleInterface
 
         return $this;
     }
+
+    /**
+     * Add a subselect expression to the query.
+     *
+     * @param  \Closure|$this|string  $query
+     * @param  string  $as
+     * @return $this
+     *
+     * @throws \InvalidArgumentException
+     */
+    public function selectSub($query, $as)
+    {
+        if(get_class($query) == self::class) {
+            $this->appendCacheTags($query->getCacheTags() ?? []);
+        }
+
+        return parent::selectSub($query, $as);
+    }
 }

--- a/src/Traits/QueryCacheModule.php
+++ b/src/Traits/QueryCacheModule.php
@@ -273,6 +273,19 @@ trait QueryCacheModule
     }
 
     /**
+     * Append tags to the cache.
+     *
+     * @param  array  $cacheTags
+     * @return \Rennokki\QueryCache\Query\Builder
+     */
+    public function appendCacheTags(array $cacheTags = [])
+    {
+        $this->cacheTags = array_unique(array_merge($this->cacheTags ?? [], $cacheTags));
+
+        return $this;
+    }
+
+    /**
      * Use a specific cache driver.
      *
      * @param  string  $cacheDriver

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -3,9 +3,12 @@
 namespace Rennokki\QueryCache\Test\Models;
 
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use Rennokki\QueryCache\Traits\QueryCacheable;
 
 class User extends Authenticatable
 {
+    use QueryCacheable;
+
     protected $fillable = [
         'name', 'email', 'password',
     ];
@@ -19,5 +22,10 @@ class User extends Authenticatable
         return [
             //
         ];
+    }
+
+    public function posts()
+    {
+        return $this->hasMany(Post::class);
     }
 }

--- a/tests/database/migrations/2018_07_14_183253_posts.php
+++ b/tests/database/migrations/2018_07_14_183253_posts.php
@@ -15,6 +15,7 @@ class Posts extends Migration
     {
         Schema::create('posts', function (Blueprint $table) {
             $table->increments('id');
+            $table->unsignedBigInteger('user_id')->nullable();
             $table->string('name');
             $table->timestamps();
         });


### PR DESCRIPTION
This PR adds the capability to append cache tags to the query rather than keeping track of them and adding them all manually at the end.

This functionality can be useful when there is a need to add additional tags based on programmatically added conditions. Additionally in cases such as the above or with long queries it can also become hard to keep track of which tags have been added especially if the query gets passed around through various methods.

It also introduces an override of the selectSub QueryBuilder statement in order to popout the cache tags of a withCount sub query into the parent query.