### PR TITLE
Update QueryCacheable.php, enable global env() #44

### DIFF
--- a/src/Traits/QueryCacheable.php
+++ b/src/Traits/QueryCacheable.php
@@ -57,7 +57,7 @@ trait QueryCacheable
             $connection->getPostProcessor()
         );
 
-        $this->cacheFor
+        $this->cacheFor || env('CACHE_FOR')
             ? $builder->cacheFor($this->cacheFor)
             : $builder->dontCache();
 


### PR DESCRIPTION
Issue #44 - Instead of having to manually specify `protected $cacheFor` in every model, simply apply `env('CACHE_FOR')` on every Model where `use \Rennokki\QueryCache\Traits\QueryCacheable;` trait is installed :)