### PR TITLE
[2.x] Pass optional boolean parameter to dontCache()

### DIFF
--- a/src/Traits/QueryCacheModule.php
+++ b/src/Traits/QueryCacheModule.php
@@ -227,8 +227,8 @@ trait QueryCacheModule
 
     /**
      * Indicate that the query should not be cached.
-     * 
-     * @param bool $avoidCache
+     *
+     * @param  bool  $avoidCache
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function dontCache(bool $avoidCache = true)

--- a/src/Traits/QueryCacheModule.php
+++ b/src/Traits/QueryCacheModule.php
@@ -241,7 +241,7 @@ trait QueryCacheModule
     /**
      * Alias for dontCache().
      *
-     * @param bool $avoidCache
+     * @param  bool  $avoidCache
      * @return \Illuminate\Database\Query\Builder|static
      */
     public function doNotCache(bool $avoidCache = true)

--- a/src/Traits/QueryCacheModule.php
+++ b/src/Traits/QueryCacheModule.php
@@ -227,12 +227,13 @@ trait QueryCacheModule
 
     /**
      * Indicate that the query should not be cached.
-     *
+     * 
+     * @param bool $avoidCache
      * @return \Illuminate\Database\Query\Builder|static
      */
-    public function dontCache()
+    public function dontCache(bool $avoidCache = true)
     {
-        $this->avoidCache = true;
+        $this->avoidCache = $avoidCache;
 
         return $this;
     }
@@ -240,11 +241,12 @@ trait QueryCacheModule
     /**
      * Alias for dontCache().
      *
+     * @param bool $avoidCache
      * @return \Illuminate\Database\Query\Builder|static
      */
-    public function doNotCache()
+    public function doNotCache(bool $avoidCache = true)
     {
-        return $this->dontCache();
+        return $this->dontCache($avoidCache);
     }
 
     /**


### PR DESCRIPTION
Introduction of ``$avoidCache`` bool param to provide a possibility to don't save cache based on a boolean clausule.

Fix: https://github.com/renoki-co/laravel-eloquent-query-cache/issues/73#issue-942481402