### PR TITLE
Adds doc comment for type hinting

### DIFF
--- a/src/Traits/QueryCacheable.php
+++ b/src/Traits/QueryCacheable.php
@@ -5,6 +5,11 @@ namespace Rennokki\QueryCache\Traits;
 use Rennokki\QueryCache\FlushQueryCacheObserver;
 use Rennokki\QueryCache\Query\Builder;
 
+/**
+ * @method static \Illuminate\Database\Query\Builder|static cacheForever()
+ * @method static \Illuminate\Database\Query\Builder|static dontCache()
+ * @method static \Illuminate\Database\Query\Builder|static doNotCache()
+ */
 trait QueryCacheable
 {
     /**


### PR DESCRIPTION
This PR adds doc comment which declares the method signatures for the following methods:

- cacheForever
- dontCache
- doNotCache

These help in IDEs to know what methods can be called.