### PR TITLE
[3.x] Cache by methods defined in the model

### DIFF
--- a/src/FlushQueryCacheObserver.php
+++ b/src/FlushQueryCacheObserver.php
@@ -147,6 +147,7 @@ class FlushQueryCacheObserver
      * @param  string|null  $relation
      * @param  \Illuminate\Database\Eloquent\Collection|null  $pivotedModels
      * @return void
+     *
      * @throws Exception
      */
     protected function invalidateCache(Model $model, $relation = null, $pivotedModels = null): void

--- a/src/Traits/QueryCacheable.php
+++ b/src/Traits/QueryCacheable.php
@@ -91,20 +91,40 @@ trait QueryCacheable
             $builder->cacheFor($this->cacheFor);
         }
 
+        if (method_exists($this, 'cacheForValue')) {
+            $builder->cacheFor($this->cacheForValue($builder));
+        }
+
         if ($this->cacheTags) {
             $builder->cacheTags($this->cacheTags);
+        }
+
+        if (method_exists($this, 'cacheTagsValue')) {
+            $builder->cacheTags($this->cacheTagsValue($builder));
         }
 
         if ($this->cachePrefix) {
             $builder->cachePrefix($this->cachePrefix);
         }
 
+        if (method_exists($this, 'cachePrefixValue')) {
+            $builder->cachePrefix($this->cachePrefixValue($builder));
+        }
+
         if ($this->cacheDriver) {
             $builder->cacheDriver($this->cacheDriver);
         }
 
+        if (method_exists($this, 'cacheDriverValue')) {
+            $builder->cacheDriver($this->cacheDriverValue($builder));
+        }
+
         if ($this->cacheUsePlainKey) {
             $builder->withPlainKey();
+        }
+
+        if (method_exists($this, 'cacheUsePlainKeyValue')) {
+            $builder->withPlainKey($this->cacheUsePlainKeyValue($builder));
         }
 
         return $builder->cacheBaseTags($this->getCacheBaseTags());

--- a/tests/Models/Book.php
+++ b/tests/Models/Book.php
@@ -14,4 +14,14 @@ class Book extends Model
     protected $fillable = [
         'name',
     ];
+
+    protected function cacheUsePlainKeyValue()
+    {
+        return $this->cacheUsePlainKey;
+    }
+
+    protected function cacheForValue()
+    {
+        return 3600;
+    }
 }

--- a/tests/Models/Kid.php
+++ b/tests/Models/Kid.php
@@ -21,4 +21,14 @@ class Kid extends Model
             //
         ];
     }
+
+    protected function cacheUsePlainKeyValue()
+    {
+        return $this->cacheUsePlainKey;
+    }
+
+    protected function cacheForValue()
+    {
+        return 3600;
+    }
 }

--- a/tests/Models/Page.php
+++ b/tests/Models/Page.php
@@ -23,4 +23,14 @@ class Page extends Model
             'test',
         ];
     }
+
+    protected function cacheUsePlainKeyValue()
+    {
+        return $this->cacheUsePlainKey;
+    }
+
+    protected function cacheForValue()
+    {
+        return 3600;
+    }
 }

--- a/tests/Models/Post.php
+++ b/tests/Models/Post.php
@@ -21,4 +21,14 @@ class Post extends Model
             //
         ];
     }
+
+    protected function cacheUsePlainKeyValue()
+    {
+        return $this->cacheUsePlainKey;
+    }
+
+    protected function cacheForValue()
+    {
+        return 3600;
+    }
 }

--- a/tests/Models/Role.php
+++ b/tests/Models/Role.php
@@ -21,4 +21,14 @@ class Role extends Model
             //
         ];
     }
+
+    protected function cacheUsePlainKeyValue()
+    {
+        return $this->cacheUsePlainKey;
+    }
+
+    protected function cacheForValue()
+    {
+        return 3600;
+    }
 }

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -32,6 +32,16 @@ class User extends Authenticatable
         ];
     }
 
+    protected function cacheUsePlainKeyValue()
+    {
+        return $this->cacheUsePlainKey;
+    }
+
+    protected function cacheForValue()
+    {
+        return 3600;
+    }
+
     public function getCacheTagsToInvalidateOnUpdate($relation = null, $pivotedModels = null): array
     {
         if ($relation === 'roles') {


### PR DESCRIPTION
Closes #89

Alongside with defined properties like `$cacheFor` or `$cacheTags`, you may now be able to define one of the following functions to define the values programmatically, by running some logic and returning a value.

These methods replace the values defined as properties.

```php
class Post extends Model
{
    use QueryCacheable;

    protected function cacheForValue($query)
    {
        return 3600;
    }

    protected function cacheTagsValue($query)
    {
        return [
            //
        ];
    }

    protected function cachePrefixValue($query)
    {
        return 'some-prefix';
    }

    protected function cacheDriverValue($query)
    {
        return 'redis';
    }

    protected function cacheUsePlainKeyValue($query)
    {
        return true;
    }
}
```