### PR TITLE
Changed getCacheKey to use the method name instead of hardcoding to get

### DIFF
--- a/src/Traits/QueryCacheModule.php
+++ b/src/Traits/QueryCacheModule.php
@@ -75,7 +75,7 @@ trait QueryCacheModule
             $this->columns = $columns;
         }
 
-        $key = $this->getCacheKey('get');
+        $key = $this->getCacheKey($method);
         $cache = $this->getCache();
         $callback = $this->getQueryCacheCallback($method, $columns, $id);
         $time = $this->getCacheTime();


### PR DESCRIPTION
Hi,

I implemented my own "exists" method using the examples you outline here:

https://leqc.renoki.org/advanced/implement-caching/implementing-cache-for-other-functions-than-get

My code: 

`public function exists()
    {
        if (! $this->shouldAvoidCache()) {
            return $this->getFromQueryCache('exists');
        }
        return parent::exists();
    }`

However, the getFromQueryCache ignores the $method when creating the cache key and always uses "get". 

What happened was I ran the exists() first, which cached the query in Redis as a bool. 

Then, when I ran the get() it found the cache entry and returned that and then Laravel blew up as it was expecting a collection , but it got a bool. 

I changed the code so that the key will use the $method variable and it solved my problem. Now exists and get are different entries in the cache. 

I would think this would be a widespread problem for anyone trying to implement methods (other than the get) as they would always be sharing the same "get" key in the cache. Of course, if the method they were using ultimately retrieved the "get" data from the cache it would be fine. 

However, with exists it's just storing the result (boolean) in the cache which is problematic for subsequent calls with the same key that expect a collection (or some result other than a boolean). 

Thanks!

-Rob