### PR TITLE
[fix] Changed `getCacheBaseTags` to use `static` instead of `self`

### DIFF
--- a/src/Traits/QueryCacheable.php
+++ b/src/Traits/QueryCacheable.php
@@ -55,7 +55,7 @@ trait QueryCacheable
     protected function getCacheBaseTags(): array
     {
         return [
-            (string) self::class,
+            (string) static::class,
         ];
     }
 


### PR DESCRIPTION
Hello,
I think late static binding should be used here. 
Otherwise, when inheriting model, all subclasses will have one tag of the parent class.