### PR TITLE
[fix] Returning `null` in `cacheForValue()` doesn't disable caching

### DIFF
--- a/src/Traits/QueryCacheModule.php
+++ b/src/Traits/QueryCacheModule.php
@@ -204,13 +204,13 @@ trait QueryCacheModule
     /**
      * Indicate that the query results should be cached.
      *
-     * @param  \DateTime|int  $time
+     * @param  \DateTime|int|null  $time
      * @return \Rennokki\QueryCache\Traits\QueryCacheModule
      */
     public function cacheFor($time)
     {
         $this->cacheTime = $time;
-        $this->avoidCache = false;
+        $this->avoidCache = $time === null;
 
         return $this;
     }


### PR DESCRIPTION
Fix to disable cache by using  cacheForValue() method. See https://github.com/renoki-co/laravel-eloquent-query-cache/issues/100

Closes #100 