### PR TITLE
Get cache tags once when invalidating

### DIFF
--- a/src/FlushQueryCacheObserver.php
+++ b/src/FlushQueryCacheObserver.php
@@ -154,12 +154,12 @@ class FlushQueryCacheObserver
     {
         $class = get_class($model);
 
-        if (! $model->getCacheTagsToInvalidateOnUpdate($relation, $pivotedModels)) {
+        $tags = $model->getCacheTagsToInvalidateOnUpdate($relation, $pivotedModels);
+
+        if (! $tags) {
             throw new Exception('Automatic invalidation for '.$class.' works only if at least one tag to be invalidated is specified.');
         }
 
-        $class::flushQueryCache(
-            $model->getCacheTagsToInvalidateOnUpdate($relation, $pivotedModels)
-        );
+        $class::flushQueryCache($tags);
     }
 }


### PR DESCRIPTION
I'm using an overridden `getCacheTagsToInvalidateOnUpdate()` to track how many times each tag is invalidated. The way `invalidateCache()` was originally written calls the `getCacheTagsToInvalidateOnUpdate()` method twice, resulting in the tags being counted twice for each invalidation. This change simply assigns the tags to a variable and uses the variable instead of calling the method directly.

FWIW, this is what I'm doing to track the tag invalidations. Just a simple array saved to the cache.

```php
public function getCacheTagsToInvalidateOnUpdate($relation = null, $pivotedModels = null): array
{
    $tags = $this->getCacheBaseTags();

    $invalidations = Cache::get('cache-invalidations', []);

    foreach ($tags as $tag) {
        $invalidations[$tag] = ($invalidations[$tag] ?? 0) + 1;
    }

    Cache::forever('cache-invalidations', $invalidations);

    return $tags;
}
```