### PR TITLE
Added option to disable caching globally

### DIFF
--- a/src/Traits/QueryCacheModule.php
+++ b/src/Traits/QueryCacheModule.php
@@ -366,6 +366,10 @@ trait QueryCacheModule
      */
     public function shouldAvoidCache(): bool
     {
+        if (config('eloquent-query-cache.enabled') === false){
+            return true;
+        }
+        
         return $this->avoidCache;
     }
 

--- a/src/config/eloquent-query-cache.php
+++ b/src/config/eloquent-query-cache.php
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * If set to false, caching will be disabled globally.
+ */
+return [
+    'enabled' => env('ELOQUENT_QUERY_CACHE_ENABLED', true),
+];


### PR DESCRIPTION
Added option to globally disable caching without touching any models. Very useful to use before each test without creating unnecessary caches and without worrying about adding dontCache() to eloquent.

