### PR TITLE
Removed deprecations to work with PHP 8.2

### DIFF
--- a/src/Contracts/QueryCacheModuleInterface.php
+++ b/src/Contracts/QueryCacheModuleInterface.php
@@ -12,7 +12,7 @@ interface QueryCacheModuleInterface
      * @param  string|null  $appends
      * @return string
      */
-    public function generatePlainCacheKey(string $method = 'get', string $id = null, string $appends = null): string;
+    public function generatePlainCacheKey(string $method = 'get', string $id = null, ?string $appends = null): string;
 
     /**
      * Get the query cache callback.
@@ -22,5 +22,5 @@ interface QueryCacheModuleInterface
      * @param  string|null  $id
      * @return \Closure
      */
-    public function getQueryCacheCallback(string $method = 'get', $columns = ['*'], string $id = null);
+    public function getQueryCacheCallback(string $method = 'get', $columns = ['*'], ?string $id = null);
 }

--- a/src/FlushQueryCacheObserver.php
+++ b/src/FlushQueryCacheObserver.php
@@ -3,6 +3,7 @@
 namespace Rennokki\QueryCache;
 
 use Exception;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 
 class FlushQueryCacheObserver
@@ -150,7 +151,7 @@ class FlushQueryCacheObserver
      *
      * @throws Exception
      */
-    protected function invalidateCache(Model $model, $relation = null, $pivotedModels = null): void
+    protected function invalidateCache(Model $model, $relation = null, ?Collection $pivotedModels = null): void
     {
         $class = get_class($model);
 

--- a/src/Traits/QueryCacheModule.php
+++ b/src/Traits/QueryCacheModule.php
@@ -69,7 +69,7 @@ trait QueryCacheModule
      * @param  string|null  $id
      * @return array
      */
-    public function getFromQueryCache(string $method = 'get', array $columns = ['*'], string $id = null)
+    public function getFromQueryCache(string $method = 'get', array $columns = ['*'], ?string $id = null)
     {
         if (is_null($this->columns)) {
             $this->columns = $columns;
@@ -95,7 +95,7 @@ trait QueryCacheModule
      * @param  string|null  $id
      * @return \Closure
      */
-    public function getQueryCacheCallback(string $method = 'get', $columns = ['*'], string $id = null)
+    public function getQueryCacheCallback(string $method = 'get', $columns = ['*'], ?string $id = null)
     {
         return function () use ($method, $columns) {
             $this->avoidCache = true;
@@ -112,7 +112,7 @@ trait QueryCacheModule
      * @param  string|null  $appends
      * @return string
      */
-    public function getCacheKey(string $method = 'get', string $id = null, string $appends = null): string
+    public function getCacheKey(string $method = 'get', ?string $id = null, ?string $appends = null): string
     {
         $key = $this->generateCacheKey($method, $id, $appends);
         $prefix = $this->getCachePrefix();
@@ -128,7 +128,7 @@ trait QueryCacheModule
      * @param  string|null  $appends
      * @return string
      */
-    public function generateCacheKey(string $method = 'get', string $id = null, string $appends = null): string
+    public function generateCacheKey(string $method = 'get', ?string $id = null, ?string $appends = null): string
     {
         $key = $this->generatePlainCacheKey($method, $id, $appends);
 
@@ -147,7 +147,7 @@ trait QueryCacheModule
      * @param  string|null  $appends
      * @return string
      */
-    public function generatePlainCacheKey(string $method = 'get', string $id = null, string $appends = null): string
+    public function generatePlainCacheKey(string $method = 'get', ?string $id = null, ?string $appends = null): string
     {
         $name = $this->connection->getName();
 

--- a/src/Traits/QueryCacheable.php
+++ b/src/Traits/QueryCacheable.php
@@ -2,6 +2,7 @@
 
 namespace Rennokki\QueryCache\Traits;
 
+use Illuminate\Database\Eloquent\Collection;
 use Rennokki\QueryCache\FlushQueryCacheObserver;
 use Rennokki\QueryCache\Query\Builder;
 
@@ -68,7 +69,7 @@ trait QueryCacheable
      * @param  \Illuminate\Database\Eloquent\Collection|null  $pivotedModels
      * @return array
      */
-    public function getCacheTagsToInvalidateOnUpdate($relation = null, $pivotedModels = null): array
+    public function getCacheTagsToInvalidateOnUpdate($relation = null, ?Collection $pivotedModels = null): array
     {
         /** @var \Illuminate\Database\Eloquent\Model $this */
         return $this->getCacheBaseTags();

--- a/tests/Models/User.php
+++ b/tests/Models/User.php
@@ -4,6 +4,7 @@ namespace Rennokki\QueryCache\Test\Models;
 
 use Chelout\RelationshipEvents\Concerns\HasBelongsToManyEvents;
 use Chelout\RelationshipEvents\Traits\HasRelationshipObservables;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Rennokki\QueryCache\Traits\QueryCacheable;
 
@@ -42,7 +43,7 @@ class User extends Authenticatable
         return 3600;
     }
 
-    public function getCacheTagsToInvalidateOnUpdate($relation = null, $pivotedModels = null): array
+    public function getCacheTagsToInvalidateOnUpdate($relation = null, ?Collection $pivotedModels = null): array
     {
         if ($relation === 'roles') {
             $tags = array_reduce($pivotedModels->all(), function ($tags, Role $role) {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -15,7 +15,10 @@ abstract class TestCase extends Orchestra
     {
         parent::setUp();
 
-        if ($this->getProvidedData() && method_exists(Model::class, 'preventAccessingMissingAttributes')) {
+        if (method_exists($this, 'getProvidedData')
+            && $this->getProvidedData()
+            && method_exists(Model::class, 'preventAccessingMissingAttributes')
+        ) {
             [$strict] = $this->getProvidedData();
             Model::preventAccessingMissingAttributes($strict);
         }
@@ -99,7 +102,7 @@ abstract class TestCase extends Orchestra
      * @param  array|null  $tags
      * @return mixed
      */
-    protected function getCacheWithTags(string $key, $tags = null)
+    protected function getCacheWithTags(string $key, ?array $tags = null)
     {
         return $this->driverSupportsTags()
             ? Cache::tags($tags)->get($key)


### PR DESCRIPTION
There isn't much to say on this. It's not fixing a bug or creating a feature, just fixing a deprecation in the latest PHP 8.4.

I have also added a method_exists into the TestCase as something in the recent versions is breaking with Orchestrator. Although there are still **previous** problems with Limewire tests.

This should fix https://github.com/renoki-co/laravel-eloquent-query-cache/issues/231