### PR TITLE
Fix PHP dep. warnings

### DIFF
--- a/src/Contracts/QueryCacheModuleInterface.php
+++ b/src/Contracts/QueryCacheModuleInterface.php
@@ -12,7 +12,7 @@ interface QueryCacheModuleInterface
      * @param  string|null  $appends
      * @return string
      */
-    public function generatePlainCacheKey(string $method = 'get', string $id = null, string $appends = null): string;
+    public function generatePlainCacheKey(string $method = 'get', ?string $id = null, ?string $appends = null): string;
 
     /**
      * Get the query cache callback.
@@ -22,5 +22,5 @@ interface QueryCacheModuleInterface
      * @param  string|null  $id
      * @return \Closure
      */
-    public function getQueryCacheCallback(string $method = 'get', $columns = ['*'], string $id = null);
+    public function getQueryCacheCallback(string $method = 'get', $columns = ['*'], ?string $id = null);
 }

--- a/src/FlushQueryCacheObserver.php
+++ b/src/FlushQueryCacheObserver.php
@@ -3,6 +3,7 @@
 namespace Rennokki\QueryCache;
 
 use Exception;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 
 class FlushQueryCacheObserver
@@ -150,14 +151,14 @@ class FlushQueryCacheObserver
      *
      * @throws Exception
      */
-    protected function invalidateCache(Model $model, $relation = null, $pivotedModels = null): void
+    protected function invalidateCache(Model $model, ?string $relation = null, ?Collection $pivotedModels = null): void
     {
         $class = get_class($model);
 
         $tags = $model->getCacheTagsToInvalidateOnUpdate($relation, $pivotedModels);
 
         if (! $tags) {
-            throw new Exception('Automatic invalidation for '.$class.' works only if at least one tag to be invalidated is specified.');
+            throw new Exception('Automatic invalidation for ' . $class . ' works only if at least one tag to be invalidated is specified.');
         }
 
         $class::flushQueryCache($tags);

--- a/src/FlushQueryCacheObserver.php
+++ b/src/FlushQueryCacheObserver.php
@@ -158,7 +158,7 @@ class FlushQueryCacheObserver
         $tags = $model->getCacheTagsToInvalidateOnUpdate($relation, $pivotedModels);
 
         if (! $tags) {
-            throw new Exception('Automatic invalidation for ' . $class . ' works only if at least one tag to be invalidated is specified.');
+            throw new Exception('Automatic invalidation for '.$class.' works only if at least one tag to be invalidated is specified.');
         }
 
         $class::flushQueryCache($tags);

--- a/src/Traits/QueryCacheModule.php
+++ b/src/Traits/QueryCacheModule.php
@@ -95,7 +95,7 @@ trait QueryCacheModule
      * @param  string|null  $id
      * @return \Closure
      */
-    public function getQueryCacheCallback(string $method = 'get', $columns = ['*'], string $id = null)
+    public function getQueryCacheCallback(string $method = 'get', $columns = ['*'], ?string $id = null)
     {
         return function () use ($method, $columns) {
             $this->avoidCache = true;

--- a/src/Traits/QueryCacheModule.php
+++ b/src/Traits/QueryCacheModule.php
@@ -153,10 +153,10 @@ trait QueryCacheModule
 
         // Count has no Sql, that's why it can't be used ->toSql()
         if ($method === 'count') {
-            return $name . $method . $id . serialize($this->getBindings()) . $appends;
+            return $name.$method.$id.serialize($this->getBindings()).$appends;
         }
 
-        return $name . $method . $id . $this->toSql() . serialize($this->getBindings()) . $appends;
+        return $name.$method.$id.$this->toSql().serialize($this->getBindings()).$appends;
     }
 
     /**

--- a/src/Traits/QueryCacheModule.php
+++ b/src/Traits/QueryCacheModule.php
@@ -69,7 +69,7 @@ trait QueryCacheModule
      * @param  string|null  $id
      * @return array
      */
-    public function getFromQueryCache(string $method = 'get', array $columns = ['*'], string $id = null)
+    public function getFromQueryCache(string $method = 'get', array $columns = ['*'], ?string $id = null)
     {
         if (is_null($this->columns)) {
             $this->columns = $columns;
@@ -112,7 +112,7 @@ trait QueryCacheModule
      * @param  string|null  $appends
      * @return string
      */
-    public function getCacheKey(string $method = 'get', string $id = null, string $appends = null): string
+    public function getCacheKey(string $method = 'get', ?string $id = null, ?string $appends = null): string
     {
         $key = $this->generateCacheKey($method, $id, $appends);
         $prefix = $this->getCachePrefix();
@@ -128,7 +128,7 @@ trait QueryCacheModule
      * @param  string|null  $appends
      * @return string
      */
-    public function generateCacheKey(string $method = 'get', string $id = null, string $appends = null): string
+    public function generateCacheKey(string $method = 'get', ?string $id = null, ?string $appends = null): string
     {
         $key = $this->generatePlainCacheKey($method, $id, $appends);
 
@@ -147,16 +147,16 @@ trait QueryCacheModule
      * @param  string|null  $appends
      * @return string
      */
-    public function generatePlainCacheKey(string $method = 'get', string $id = null, string $appends = null): string
+    public function generatePlainCacheKey(string $method = 'get', ?string $id = null, ?string $appends = null): string
     {
         $name = $this->connection->getName();
 
         // Count has no Sql, that's why it can't be used ->toSql()
         if ($method === 'count') {
-            return $name.$method.$id.serialize($this->getBindings()).$appends;
+            return $name . $method . $id . serialize($this->getBindings()) . $appends;
         }
 
-        return $name.$method.$id.$this->toSql().serialize($this->getBindings()).$appends;
+        return $name . $method . $id . $this->toSql() . serialize($this->getBindings()) . $appends;
     }
 
     /**

--- a/src/Traits/QueryCacheable.php
+++ b/src/Traits/QueryCacheable.php
@@ -2,6 +2,7 @@
 
 namespace Rennokki\QueryCache\Traits;
 
+use Illuminate\Database\Eloquent\Collection;
 use Rennokki\QueryCache\FlushQueryCacheObserver;
 use Rennokki\QueryCache\Query\Builder;
 
@@ -68,7 +69,7 @@ trait QueryCacheable
      * @param  \Illuminate\Database\Eloquent\Collection|null  $pivotedModels
      * @return array
      */
-    public function getCacheTagsToInvalidateOnUpdate($relation = null, $pivotedModels = null): array
+    public function getCacheTagsToInvalidateOnUpdate(?string $relation = null, ?Collection $pivotedModels = null): array
     {
         /** @var \Illuminate\Database\Eloquent\Model $this */
         return $this->getCacheBaseTags();


### PR DESCRIPTION
Hey, I've noticed that PR: https://github.com/renoki-co/laravel-eloquent-query-cache/pull/234 is stuck.

Fixed the PHP dep. warnings, should fix: https://github.com/renoki-co/laravel-eloquent-query-cache/issues/231
